### PR TITLE
Fix VSSDK links to MSDN in documentation

### DIFF
--- a/AdditionalSdkDocumentation/AdditionalSdkDocumentation.shfbproj
+++ b/AdditionalSdkDocumentation/AdditionalSdkDocumentation.shfbproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <!-- The configuration and platform will be used to determine which assemblies to include from solution and
+				 project documentation sources -->
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>9985e075-5acf-48a3-9402-3fc2f114d71d</ProjectGuid>
+    <SHFBSchemaVersion>1.9.9.0</SHFBSchemaVersion>
+    <!-- AssemblyName, Name, and RootNamespace are not used by SHFB but Visual Studio adds them anyway -->
+    <AssemblyName>AdditionalSdkDocumentation</AssemblyName>
+    <RootNamespace>AdditionalSdkDocumentation</RootNamespace>
+    <Name>AdditionalSdkDocumentation</Name>
+    <!-- SHFB properties -->
+    <FrameworkVersion>.NET Framework 4.0</FrameworkVersion>
+    <OutputPath>.\Help\</OutputPath>
+    <HtmlHelpName>AdditionalSdkDocumentation</HtmlHelpName>
+    <Language>en-US</Language>
+    <TransformComponentArguments>
+      <Argument Key="logoFile" Value="Help.png" xmlns="" />
+      <Argument Key="logoHeight" Value="" xmlns="" />
+      <Argument Key="logoWidth" Value="" xmlns="" />
+      <Argument Key="logoAltText" Value="" xmlns="" />
+      <Argument Key="logoPlacement" Value="left" xmlns="" />
+      <Argument Key="logoAlignment" Value="left" xmlns="" />
+      <Argument Key="maxVersionParts" Value="" xmlns="" />
+    </TransformComponentArguments>
+    <DocumentationSources>
+      <DocumentationSource sourceFile="..\packages\VSSDK.OLE.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.OLE.Interop.dll" xmlns="" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.Shell.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.Shell.Interop.8.0.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.Shell.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.Shell.Interop.9.0.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.Shell.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.Shell.Interop.10.0.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.Shell.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.Shell.Interop.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.Shell.Immutable.10.10.0.0\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.TextManager.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.TextManager.Interop.8.0.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.TextManager.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.TextManager.Interop.9.0.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.TextManager.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.TextManager.Interop.10.0.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.TextManager.Interop.10.10.0.0\lib\net20\Microsoft.VisualStudio.TextManager.Interop.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.Language.10.10.0.0\lib\net40\Microsoft.VisualStudio.Language.Intellisense.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.Language.10.10.0.0\lib\net40\Microsoft.VisualStudio.Language.StandardClassification.dll" />
+      <DocumentationSource sourceFile="..\packages\VSSDK.ComponentModelHost.10.10.0.0\lib\net40\Microsoft.VisualStudio.ComponentModelHost.dll" />
+    </DocumentationSources>
+    <BuildAssemblerVerbosity>OnlyWarningsAndErrors</BuildAssemblerVerbosity>
+    <HelpFileFormat>HtmlHelp1</HelpFileFormat>
+    <IndentHtml>False</IndentHtml>
+    <KeepLogFile>True</KeepLogFile>
+    <DisableCodeBlockComponent>False</DisableCodeBlockComponent>
+    <CppCommentsFixup>False</CppCommentsFixup>
+    <CleanIntermediates>True</CleanIntermediates>
+  </PropertyGroup>
+  <!-- There are no properties for these groups.  AnyCPU needs to appear in order for Visual Studio to perform
+			 the build.  The others are optional common platform types that may appear. -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Win32' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Win32' ">
+  </PropertyGroup>
+  <!-- Import the SHFB build targets -->
+  <Import Project="$(SHFBROOT)\SandcastleHelpFileBuilder.targets" />
+</Project>

--- a/VSBase.sln
+++ b/VSBase.sln
@@ -28,6 +28,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "VSBaseDocumentation", "VSBaseDocumentation\VSBaseDocumentation.shfbproj", "{6A379261-D0A2-427C-8E7F-48895E875B1B}"
 EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "AdditionalSdkDocumentation", "AdditionalSdkDocumentation\AdditionalSdkDocumentation.shfbproj", "{9985E075-5ACF-48A3-9402-3FC2F114D71D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,9 @@ Global
 		{6A379261-D0A2-427C-8E7F-48895E875B1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A379261-D0A2-427C-8E7F-48895E875B1B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A379261-D0A2-427C-8E7F-48895E875B1B}.ReleaseNoDoc|Any CPU.ActiveCfg = Release|Any CPU
+		{9985E075-5ACF-48A3-9402-3FC2F114D71D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9985E075-5ACF-48A3-9402-3FC2F114D71D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9985E075-5ACF-48A3-9402-3FC2F114D71D}.ReleaseNoDoc|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,5 +78,6 @@ Global
 		{3539AC4E-0666-4A6E-873D-03FD8F2D8CBD} = {E5F869CB-056B-430A-8A7F-2EDEC7CC005F}
 		{0C198DA7-9D1B-4DB6-B0AD-5B72331D2A20} = {6E9188B1-D508-4DCA-9634-39E05E593EB3}
 		{6A379261-D0A2-427C-8E7F-48895E875B1B} = {16CE8FAB-F192-4E9C-88D0-3365475E519A}
+		{9985E075-5ACF-48A3-9402-3FC2F114D71D} = {16CE8FAB-F192-4E9C-88D0-3365475E519A}
 	EndGlobalSection
 EndGlobal

--- a/VSBaseDocumentation/VSBaseDocumentation.shfbproj
+++ b/VSBaseDocumentation/VSBaseDocumentation.shfbproj
@@ -62,6 +62,13 @@
       <PlugInConfig id="Lightweight TOC" enabled="True" xmlns="">
         <configuration />
       </PlugInConfig>
+      <PlugInConfig id="Additional Reference Links" enabled="True">
+        <configuration>
+          <targets>
+            <target htmlSdkLinkType="None" help2SdkLinkType="Index" helpViewerSdkLinkType="Id" websiteSdkLinkType="Msdn" helpFileProject="..\AdditionalSdkDocumentation\AdditionalSdkDocumentation.shfbproj" />
+          </targets>
+        </configuration>
+      </PlugInConfig>
     </PlugInConfigurations>
     <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected</VisibleItems>
     <RootNamespaceTitle>API Reference</RootNamespaceTitle>


### PR DESCRIPTION
This change uses the **Additional Reference Links Plug-In** for SHFB to enable the documentation produced for the VSBase library to properly link to Visual Studio SDK topics at MSDN.
1. A new project **AdditionalSdkDocumentation.shfbproj** was created.
   - This project includes the [Visual Studio SDK assemblies as documentation sources](https://github.com/tunnelvisionlabs/vsbase/blob/5cea20223dbef0addf712bbf4829d060ff396c3b/AdditionalSdkDocumentation/AdditionalSdkDocumentation.shfbproj#L30-L42).
     ![image](https://f.cloud.github.com/assets/1408396/2316293/877b1204-a331-11e3-95ff-c5ec264f5650.png)
   - When the project was added to the solution, the Visual Studio configuration manager tool was used to disable building this project for all solution configurations. The following image shows the configuration for just the **Release|AnyCPU** configuration.
     ![image](https://f.cloud.github.com/assets/1408396/2316286/5961f6b2-a331-11e3-89cc-c90d6904bd0b.png)
2. The Additional Reference Links Plug-In was configured for the VSBaseDocumentation project. The **AdditionalSdkDocumentation.shfbproj** project was added as an Additional Reference Project, and the **WebsiteSdkLinkType** property for the project was set to **Msdn**.
   ![image](https://f.cloud.github.com/assets/1408396/2316254/758dab3e-a330-11e3-9d03-ea0aa4753156.png)

This update results in all links except for one reference to `ProvideCodeBaseAttribute` getting resolved. So far, this link remains unresolved since SHFB does not support the NuGet package manager and no other project in the solution currently references the **VSSDK.Shell.11** or **VSSDK.Shell.12** NuGet packages.
